### PR TITLE
update the guest role_name parameter

### DIFF
--- a/superset2/superset_config.py
+++ b/superset2/superset_config.py
@@ -144,6 +144,10 @@ CORS_OPTIONS = {
     "origins": [os.environ["CORS_ORIGINS"].split(",")],
 }
 
+# embedding dashboard with guest token; create EmbedGamme role (a duplicate of Gamma role); 
+# add necessary datasource permissions for this role to embed a dashboard
+GUEST_ROLE_NAME = "EmbedGamma"
+
 SESSION_COOKIE_SAMESITE = None
 SESSION_COOKIE_SECURE = False
 SUPERSET_FEATURE_EMBEDDED_SUPERSET = True


### PR DESCRIPTION
The parameter `GUEST_ROLE_NAME` is used by superset to embed a dashboard. This role should have minimum `Gamma`  permissions & datasource permissions required to embed a dashboard.

Apart from this, the guest user used to fetch the token should have the following permissions:
<img width="1028" alt="Screenshot 2024-01-08 at 5 33 32 PM" src="https://github.com/DalgoT4D/docker-superset/assets/39583356/d937f53b-04b4-4287-ac5e-9073479ab5de">

Seems like by default, for any dashboard embedding the permission are read from this `GUEST_ROLE_NAME` role. However, to fetch the token & authenticate as a guest we need the above two permissions.

Even if the role for the flag `GUEST_ROLE_NAME` does not exist, the superset container(s) still run. @fatchat 
