### PR TITLE
make the redis broker url configurable

### DIFF
--- a/superset3/assets/superset_config.py
+++ b/superset3/assets/superset_config.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 from cachelib.redis import RedisCache
 from superset.superset_typing import CacheConfig
 from celery.schedules import crontab
@@ -27,7 +26,7 @@ CACHE_CONFIG: CacheConfig = {
     "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
     "CACHE_TYPE": "RedisCache",
     "CACHE_KEY_PREFIX": "superset_results",
-    "CACHE_REDIS_URL": "redis://superset_cache:6379/0",
+    "CACHE_REDIS_URL": os.environ["BROKER_URL"],
 }
 
 # Cache for datasource metadata and query results
@@ -37,7 +36,7 @@ DATA_CACHE_CONFIG: CacheConfig = {
     "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
     "CACHE_TYPE": "RedisCache",
     "CACHE_KEY_PREFIX": "superset_data_cache",
-    "CACHE_REDIS_URL": "redis://superset_cache:6379/0",
+    "CACHE_REDIS_URL": os.environ["BROKER_URL"],
 }
 
 # Cache for dashboard filter state (`CACHE_TYPE` defaults to `SimpleCache` when
@@ -48,7 +47,7 @@ FILTER_STATE_CACHE_CONFIG: CacheConfig = {
     "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
     "CACHE_TYPE": "RedisCache",
     "CACHE_KEY_PREFIX": "superset_filter_cache",
-    "CACHE_REDIS_URL": "redis://superset_cache:6379/0",
+    "CACHE_REDIS_URL": os.environ["BROKER_URL"],
 }
 
 # Cache for explore form data state (`CACHE_TYPE` defaults to `SimpleCache` when
@@ -59,21 +58,21 @@ EXPLORE_FORM_DATA_CACHE_CONFIG: CacheConfig = {
     "REFRESH_TIMEOUT_ON_RETRIEVAL": True,
     "CACHE_TYPE": "RedisCache",
     "CACHE_KEY_PREFIX": "superset_explore_form_data_cache",
-    "CACHE_REDIS_URL": "redis://superset_cache:6379/0",
+    "CACHE_REDIS_URL": os.environ["BROKER_URL"],
 }
 
 
-REDIS_HOST = "superset_cache"
+REDIS_HOST = os.environ["REDIS_HOST"]
 REDIS_PORT = "6379"
 
 
 class CeleryConfig:  # pylint: disable=too-few-public-methods
-    broker_url = "redis://superset_cache:6379/0"
+    broker_url = os.environ["BROKER_URL"]
     imports = (
         "superset.sql_lab",
         "superset.tasks",
     )
-    result_backend = "redis://superset_cache:6379/0"
+    result_backend = os.environ["BROKER_URL"]
     worker_log_level = "DEBUG"
     worker_prefetch_multiplier = 10
     task_acks_late = True
@@ -105,7 +104,7 @@ CELERY_CONFIG = CeleryConfig  # pylint: disable=invalid-name
 
 
 RESULTS_BACKEND = RedisCache(
-    host="superset_cache", port=6379, key_prefix="superset_results"
+    host=os.environ["REDIS_HOST"], port=6379, key_prefix="superset_results"
 )
 
 

--- a/superset3/superset.env.example
+++ b/superset3/superset.env.example
@@ -9,6 +9,7 @@ APP_DB_USER=superset
 APP_DB_PASS=
 APP_DB_NAME=superset
 
+REDIS_HOST=superset_cache
 BROKER_URL=redis://superset_cache:6379/0
 
 SQLALCHEMY_DATABASE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/superset


### PR DESCRIPTION
this allows us to run multiple `docker-superset` setups on a single machine

the `superset.env` needs a new variable
- `REDIS_HOST`